### PR TITLE
GSWL-ecosystem has --check-payees, meta.txt needs them

### DIFF
--- a/meta.txt
+++ b/meta.txt
@@ -57,3 +57,30 @@ account Income:Salary:IdiotsUnlimited
 account Receivables:P2PLending
 account Receivables:Flatmates
  payee Richard Flatmate
+
+; Define valid payees
+payee Deutsche Bank
+    alias \*DEUTSCHE BANK .*
+payee 01232Transact
+payee AMAZON SERVICES
+payee AT & M
+payee ATM
+    alias ^(ATM .*|Transact ATM)
+payee AVIS
+payee Airline Ltd.
+payee B&B Cmp.
+payee Bike Market
+payee Cash Expenses
+payee Children In Need
+payee Dr Dre Donation
+payee GREENPEACE
+payee Grandpa's Christmas Present
+payee HamsterWheel Ltd.
+payee HealthCharity
+payee IdiotsUnlimited
+payee MobileCompany Ltd.
+payee Mr Scrooge
+payee Opening Balance
+payee Richard Flatmate
+payee Train
+    alias Train A-NR .*


### PR DESCRIPTION
Without this running `led bal` with ledger version  3.3.2-20230330 will produce errors of this type:

    While parsing transaction:
    > 2041/09/19 * Train A-NR TPXT2AINTERNET
    Error: Unknown payee 'Train A-NR TPXT2AINTERNET'

See  [err.txt](https://github.com/rolfschr/GSWL-private/files/12778502/err.txt) for a full listing of errors that occur on my system without this fix. Perhaps ledger has gotten serious about enforcing known payees when `--check-payees` is specified as it is in the [alias](https://github.com/rolfschr/GSWL-ecosystem/blob/aa88715ff7033c8e1a8fd505f5b1868bd49a8f01/alias) file currently?

This fix also illustrates some regular expression matching fixes that are appropriate for payees in the `meta.txt` file. With the fix `led bal` yields this output: [bal.txt](https://github.com/rolfschr/GSWL-private/files/12778510/bal.txt)

